### PR TITLE
Fix header photo cut off when navigating to #home on mobile

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -90,7 +90,11 @@ export default function Nav() {
         <div className="flex items-center gap-2.5 sm:gap-3">
           <a
             href="#home"
-            onClick={() => setActiveHref("")}
+            onClick={(e) => {
+              e.preventDefault();
+              setActiveHref("");
+              window.scrollTo({ top: 0, behavior: "smooth" });
+            }}
             className="font-display text-xl sm:text-xl md:text-2xl leading-none"
             style={{ color: "var(--accent)", letterSpacing: "0.01em" }}
           >


### PR DESCRIPTION
On mobile the nav wraps to multiple rows and exceeds the 5.75rem
scroll-margin-top set on all sections, causing the browser to stop
scrolling at a non-zero position where the sticky nav overlaps the
hero. Replace anchor navigation with window.scrollTo({ top: 0 }) so
the link always scrolls the page to the very top.

https://claude.ai/code/session_01EStqxSP3P7v5v5w3Hqfg8A